### PR TITLE
Resolves #37 - Simplified 'launch-prefix' by adding CLI argument

### DIFF
--- a/ros2launch/ros2launch/api/api.py
+++ b/ros2launch/ros2launch/api/api.py
@@ -156,6 +156,12 @@ def launch_a_launch_file(
         argv=launch_file_arguments,
         noninteractive=noninteractive,
         debug=debug)
+
+    # If 'launch-prefix' launch file argument is also provided in the user input,
+    # the 'launch-prefix' option is applied since the last duplicate argument is used
+    if args is not None and args.launch_prefix is not None and len(args.launch_prefix) > 0:
+        launch_file_arguments.append(f'launch-prefix:={args.launch_prefix}')
+
     parsed_launch_arguments = parse_launch_arguments(launch_file_arguments)
     # Include the user provided launch file using IncludeLaunchDescription so that the
     # location of the current launch file is set.

--- a/ros2launch/ros2launch/command/launch.py
+++ b/ros2launch/ros2launch/command/launch.py
@@ -92,6 +92,12 @@ class LaunchCommand(CommandExtension):
             help=("Show all launched subprocesses' output by overriding their output"
                   ' configuration using the OVERRIDE_LAUNCH_PROCESS_OUTPUT envvar.')
         )
+        parser.add_argument(
+            '--launch-prefix',
+            help='Prefix command, which should go before all executables. '
+                 'Command must be wrapped in quotes if it contains spaces '
+                 "(e.g. --launch-prefix 'xterm -e gdb -ex run --args')."
+        )
         arg = parser.add_argument(
             'package_name',
             help='Name of the ROS package which contains the launch file')


### PR DESCRIPTION
Resolves: https://github.com/ros2/launch_ros/issues/37

Makes `launch-prefix` more accessible by adding a CLI argument `--launch-prefix 'LAUNCH PREFIX'` where `'LAUNCH PREFIX'` is the desired command prefix (wrapped in quotes if it contains spaces). This achieves the same behavior as setting the launch file argument `'launch-prefix:=LAUNCH PREFIX'` which applies the prefix to all executable Actions. For simplicity, the `--launch-prefix` argument  mirrors the `--prefix` argument provided by `ros2 run`.

I did not find documentation for the `ros2 launch` command specifically, but I can submit a documentation update PR to https://navigation.ros.org/tutorials/docs/get_backtrace.html if that is the best location for it.